### PR TITLE
Update factory.py

### DIFF
--- a/src/factory.py
+++ b/src/factory.py
@@ -1,12 +1,45 @@
 """Factory utily functions to create datasets and models."""
 
-from model_config import model_config_registry
-from dataset_config import dataset_config_registry
+from foundation_models import (
+    CromaModel,
+    ScaleMAEModel,
+    GFMModel,
+    DinoV2Model,
+    SoftConModel,
+    DofaModel,
+    SatMAEModel,
+    AnySatModel,
+)
+from datasets.geobench_wrapper import GeoBenchDataset
+from datasets.resisc_wrapper import Resics45Dataset
+from datasets.benv2_wrapper import BenV2Dataset
+from datasets.caffe_wrapper import CaffeDataset
+
+model_registry = {
+    "croma": CromaModel,
+    # "panopticon": PanopticonModel,
+    "scalemae": ScaleMAEModel,
+    "gfm": GFMModel,
+    "dinov2": DinoV2Model,
+    "softcon": SoftConModel,
+    "dofa": DofaModel,
+    "satmae": SatMAEModel,
+    "anysat": AnySatModel,
+    # Add other model mappings here
+}
+
+dataset_registry = {
+    "geobench": GeoBenchDataset,
+    "resisc45": Resics45Dataset,
+    "benv2": BenV2Dataset,
+    "caffe_rgb": 
+    # Add other dataset mappings here
+}
 
 
 def create_dataset(config_data):
     dataset_type = config_data.dataset_type
-    dataset_class = dataset_config_registry.get(dataset_type)
+    dataset_class = dataset_registry.get(dataset_type)
     if dataset_class is None:
         raise ValueError(f"Dataset type '{dataset_type}' not found.")
     dataset = dataset_class(config_data)
@@ -16,7 +49,7 @@ def create_dataset(config_data):
 
 def create_model(args, config_model, dataset_config=None):
     model_name = config_model.model_type
-    model_class = model_config_registry.get(model_name)
+    model_class = model_registry.get(model_name)
     if model_class is None:
         raise ValueError(f"Model type '{model_name}' not found.")
 

--- a/src/factory.py
+++ b/src/factory.py
@@ -32,7 +32,7 @@ dataset_registry = {
     "geobench": GeoBenchDataset,
     "resisc45": Resics45Dataset,
     "benv2": BenV2Dataset,
-    "caffe_rgb": 
+    "caffe_rgb": CaffeDataset
     # Add other dataset mappings here
 }
 


### PR DESCRIPTION
 I messed this up when spliitting the config, because I was confused between `model_config_registry` and `model_registry` and I think we can set this up more cleanly, i.e with hydra target a config or a class directly without having to define all these extra registry dictionariers.