### PR TITLE
Download path of FMs as Env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,12 @@ This repository provides tools for evaluating various foundation models on Earth
 
 ## Setup
 
-To get started, ensure you have the following dependencies installed:
+To get started, you can install the required dependencies from the `pyproject.toml`:
 
-```bash
-pip install torch==2.1.2
-pip install torchvision==0.16.2
-pip install numpy==1.26.4
-pip install openmim
-mim install mmengine
-mim install "mmcv==2.1.0"
-mim install mmsegmentation
-pip install tensorboard
-pip install loguru
-pip install timm
-pip install git+https://github.com/ServiceNow/geo-bench.git
-pip install torchmetrics
-pip install ftfy
-pip install regex
-pip install einops
-pip install yacs
-pip install kornia
-pip install pydantic
-pip install omegaconf
-pip install wandb
-pip install python-dotenv
-pip install torchgeo
-pip install fastparquet
+For this navigate to the root directory of this repository and do:
+
+```
+pip install -e .
 ```
 
 ### To use [ViT Adapter](https://arxiv.org/abs/2205.08534)
@@ -42,10 +22,23 @@ sh make.sh
 
 
 ### Model Weights
-Pretrained model weights are available on [Hugging Face](https://huggingface.co/XShadow/GeoFMs). Download the necessary weights for your evaluation tasks.
-The SoftCon weights are available on a different [HF repo](https://huggingface.co/wangyi111/softcon).
-DOFA weights are available in this [HF repo](https://huggingface.co/XShadow/DOFA).
-SATMAE++ weights are available in this [HF repo](https://huggingface.co/mubashir04/checkpoint_ViT-L_pretrain_fmow_sentinel).
+Pretrained model weights are available on [Hugging Face](https://huggingface.co/XShadow/GeoFMs).
+
+You can set this environment variable in your terminal with:
+
+```shell
+export MODEL_WEIGHTS_DIR=/your/custom/path
+```
+
+When using any of the FMs, the init method will check whether it can find the pre-trained checkpoint of the respective FM in the above `MODEL_WEIGHTS_DIR` and download it there if not found. If you do not change the env
+variable, the default will be `./fm_weights`.
+
+Some models depend on [torch hub](https://pytorch.org/docs/stable/hub.html#where-are-my-downloaded-models-saved), which by default will load models to `~.cache/torch/hub`. If you would like to change the directory if this to
+for example have a single place where all weights across the models are stored, you can also change
+
+```shell
+export TORCH_HOME=/your/custom/path
+```
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "GeoFM"
 version = "0.1.0"
-description = "Project with specific dependencies"
+description = "Accessible Geospatial Foundation Models with PyTorch Lightning."
 authors = [
     { name = "Zhitong Xiong", email = "xiongzhitong@gmail.com" }
+]
+
+maintainers = [
+    { name = "Zhitong Xiong", email = "xiongzhitong@gmail.com" },
+    { name = "Nils Lehmann", email = "n.lehmann@tum.de" }
 ]
 
 
@@ -35,5 +40,6 @@ dependencies = [
     "fastparquet",
     "mlflow",
     "ray>=2.40.0",
+    "huggingface-hub>=0.27.1"
 ]
 

--- a/src/configs/model/croma_cls.yaml
+++ b/src/configs/model/croma_cls.yaml
@@ -6,6 +6,6 @@ task: classification
 size: base
 modality: optical
 image_resolution: 120
-pretrained_path: "src/fm_weights/CROMA_base.pt"
+pretrained_path: "CROMA_base.pt"
 num_channels: 12
 

--- a/src/configs/model/croma_seg.yaml
+++ b/src/configs/model/croma_seg.yaml
@@ -7,6 +7,6 @@ size: base
 modality: optical
 image_resolution: 120
 embed_dim: 768
-pretrained_path: "src/fm_weights/CROMA_base.pt"
+pretrained_path: "CROMA_base.pt"
 num_channels: 12
 

--- a/src/configs/model/dofa_cls.yaml
+++ b/src/configs/model/dofa_cls.yaml
@@ -6,5 +6,5 @@ task: classification
 dofa_size: dofa_large
 image_resolution: 224
 embed_dim: 1024
-pretrained_path: "src/fm_weights/DOFA_ViT_large_e100.pth"
+pretrained_path: "DOFA_ViT_large_e100.pth"
 

--- a/src/configs/model/dofa_seg.yaml
+++ b/src/configs/model/dofa_seg.yaml
@@ -6,5 +6,5 @@ task: segmentation
 dofa_size: dofa_large
 image_resolution: 224
 embed_dim: 1024
-pretrained_path: "src/fm_weights/DOFA_ViT_large_e100.pth"
+pretrained_path: "DOFA_ViT_large_e100.pth"
 

--- a/src/configs/model/gfm_cls.yaml
+++ b/src/configs/model/gfm_cls.yaml
@@ -5,6 +5,6 @@ model_type: gfm
 task: classification
 image_resolution: 192
 embed_dim: 1024
-pretrained_path: "src/fm_weights/gfm.pth"
+pretrained_path: "gfm.pth"
 num_channels: 3
 

--- a/src/configs/model/gfm_seg.yaml
+++ b/src/configs/model/gfm_seg.yaml
@@ -5,5 +5,5 @@ model_type: gfm
 task: segmentation
 image_resolution: 192
 embed_dim: 1024
-pretrained_path: "src/fm_weights/gfm.pth"
+pretrained_path: "gfm.pth"
 num_channels: 3

--- a/src/configs/model/satmae_cls.yaml
+++ b/src/configs/model/satmae_cls.yaml
@@ -8,5 +8,5 @@ image_resolution: 96
 patch_size: 8
 num_channels: 10
 channel_groups: [[0, 1, 2, 6], [3, 4, 5, 7], [8, 9]]
-pretrained_path: "src/fm_weights/checkpoint_ViT-L_pretrain_fmow_sentinel.pth"
+pretrained_path: "checkpoint_ViT-L_pretrain_fmow_sentinel.pth"
 

--- a/src/configs/model/satmae_cls_rgb.yaml
+++ b/src/configs/model/satmae_cls_rgb.yaml
@@ -9,5 +9,5 @@ embed_dim: 1024
 image_resolution: 224
 patch_size: 16
 num_channels: 3
-pretrained_path: "src/fm_weights/checkpoint_ViT-L_pretrain_fmow_rgb.pth"
+pretrained_path: "checkpoint_ViT-L_pretrain_fmow_rgb.pth"
 

--- a/src/configs/model/satmae_seg.yaml
+++ b/src/configs/model/satmae_seg.yaml
@@ -8,4 +8,4 @@ image_resolution: 96
 patch_size: 8
 num_channels: 10
 channel_groups: [[0, 1, 2, 6], [3, 4, 5, 7], [8, 9]]
-pretrained_path: "/home/xshadow/evaluation/DOFA-pytorch/src/fm_weights/checkpoint_ViT-L_pretrain_fmow_sentinel.pth"
+pretrained_path: "checkpoint_ViT-L_pretrain_fmow_sentinel.pth"

--- a/src/configs/model/satmae_seg_rgb.yaml
+++ b/src/configs/model/satmae_seg_rgb.yaml
@@ -9,5 +9,5 @@ embed_dim: 1024
 image_resolution: 224
 patch_size: 16
 num_channels: 3
-pretrained_path: "src/fm_weights/checkpoint_ViT-L_pretrain_fmow_rgb.pth"
+pretrained_path: "checkpoint_ViT-L_pretrain_fmow_rgb.pth"
 

--- a/src/configs/model/scalemae_cls.yaml
+++ b/src/configs/model/scalemae_cls.yaml
@@ -5,6 +5,6 @@ model_type: scalemae
 task: classification
 image_resolution: 224
 embed_dim: 1024
-pretrained_path: "src/fm_weights/scalemae-vitlarge-800.pth"
+pretrained_path: "scalemae-vitlarge-800.pth"
 num_channels: 3
 

--- a/src/configs/model/scalemae_seg.yaml
+++ b/src/configs/model/scalemae_seg.yaml
@@ -5,6 +5,6 @@ model_type: scalemae
 task: segmentation
 image_resolution: 224
 embed_dim: 1024
-pretrained_path: "src/fm_weights/scalemae-vitlarge-800.pth"
+pretrained_path: "scalemae-vitlarge-800.pth"
 num_channels: 3
 

--- a/src/foundation_models/CROMA/use_croma.py
+++ b/src/foundation_models/CROMA/use_croma.py
@@ -20,25 +20,25 @@ class PretrainedCROMA(nn.Module):
         """
         super().__init__()
         # check types
-        assert isinstance(
-            pretrained_path, str
-        ), f"pretrained_path must be a string, not {type(pretrained_path)}"
+        assert isinstance(pretrained_path, str), (
+            f"pretrained_path must be a string, not {type(pretrained_path)}"
+        )
         assert isinstance(size, str), f"size must be a string, not {type(size)}"
-        assert isinstance(
-            modality, str
-        ), f"modality must be a string, not {type(modality)}"
-        assert isinstance(
-            image_resolution, int
-        ), f"image_resolution must be an int, not {type(image_resolution)}"
+        assert isinstance(modality, str), (
+            f"modality must be a string, not {type(modality)}"
+        )
+        assert isinstance(image_resolution, int), (
+            f"image_resolution must be an int, not {type(image_resolution)}"
+        )
 
         # check values
         assert size in [
             "base",
             "large",
         ], f"size must be either base or large, not {size}"
-        assert (
-            image_resolution % 8 == 0
-        ), f"image_resolution must be a multiple of 8, not {image_resolution}"
+        assert image_resolution % 8 == 0, (
+            f"image_resolution must be a multiple of 8, not {image_resolution}"
+        )
         assert modality in [
             "both",
             "SAR",
@@ -135,9 +135,9 @@ class PretrainedCROMA(nn.Module):
     def forward(self, SAR_images=None, optical_images=None):
         return_dict = {}
         if self.modality in ["SAR", "both"]:
-            assert (
-                SAR_images is not None
-            ), f"Modality is set to {self.modality}, but SAR_images are None"
+            assert SAR_images is not None, (
+                f"Modality is set to {self.modality}, but SAR_images are None"
+            )
             SAR_encodings = self.s1_encoder(
                 imgs=SAR_images, attn_bias=self.attn_bias.to(SAR_images.device)
             )  # (bsz, num_patches, encoder_dim)
@@ -146,9 +146,9 @@ class PretrainedCROMA(nn.Module):
             return_dict["SAR_GAP"] = SAR_GAP
 
         if self.modality in ["optical", "both"]:
-            assert (
-                optical_images is not None
-            ), f"Modality is set to {self.modality}, but optical_images are None"
+            assert optical_images is not None, (
+                f"Modality is set to {self.modality}, but optical_images are None"
+            )
             optical_encodings, out_feats = self.s2_encoder(
                 imgs=optical_images, attn_bias=self.attn_bias.to(optical_images.device)
             )  # (bsz, num_patches, encoder_dim)

--- a/src/foundation_models/DOFA/wave_dynamic_layer.py
+++ b/src/foundation_models/DOFA/wave_dynamic_layer.py
@@ -75,10 +75,10 @@ class GaussianFourierFeatureTransform(torch.nn.Module):
 
         batches, channels, width, height = x.shape
 
-        assert (
-            channels == self._num_input_channels
-        ), "Expected input to have {} channels (got {} channels)".format(
-            self._num_input_channels, channels
+        assert channels == self._num_input_channels, (
+            "Expected input to have {} channels (got {} channels)".format(
+                self._num_input_channels, channels
+            )
         )
 
         # Make shape compatible for matmul with _B.

--- a/src/foundation_models/GFM/swin_transformer.py
+++ b/src/foundation_models/GFM/swin_transformer.py
@@ -246,9 +246,9 @@ class SwinTransformerBlock(nn.Module):
             # if window size is larger than input resolution, we don't partition windows
             self.shift_size = 0
             self.window_size = min(self.input_resolution)
-        assert (
-            0 <= self.shift_size < self.window_size
-        ), "shift_size must in 0-window_size"
+        assert 0 <= self.shift_size < self.window_size, (
+            "shift_size must in 0-window_size"
+        )
 
         self.norm1 = norm_layer(dim)
         self.attn = WindowAttention(
@@ -559,9 +559,9 @@ class PatchEmbed(nn.Module):
     def forward(self, x):
         B, C, H, W = x.shape
         # FIXME look at relaxing size constraints
-        assert (
-            H == self.img_size[0] and W == self.img_size[1]
-        ), f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]})."
+        assert H == self.img_size[0] and W == self.img_size[1], (
+            f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]})."
+        )
         x = self.proj(x).flatten(2).transpose(1, 2)  # B Ph*Pw C
         if self.norm is not None:
             x = self.norm(x)

--- a/src/foundation_models/GFM/swin_transformer_seg.py
+++ b/src/foundation_models/GFM/swin_transformer_seg.py
@@ -247,9 +247,9 @@ class SwinTransformerBlock(nn.Module):
             # if window size is larger than input resolution, we don't partition windows
             self.shift_size = 0
             self.window_size = min(self.input_resolution)
-        assert (
-            0 <= self.shift_size < self.window_size
-        ), "shift_size must in 0-window_size"
+        assert 0 <= self.shift_size < self.window_size, (
+            "shift_size must in 0-window_size"
+        )
 
         self.norm1 = norm_layer(dim)
         self.attn = WindowAttention(
@@ -560,9 +560,9 @@ class PatchEmbed(nn.Module):
     def forward(self, x):
         B, C, H, W = x.shape
         # FIXME look at relaxing size constraints
-        assert (
-            H == self.img_size[0] and W == self.img_size[1]
-        ), f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]})."
+        assert H == self.img_size[0] and W == self.img_size[1], (
+            f"Input image size ({H}*{W}) doesn't match model ({self.img_size[0]}*{self.img_size[1]})."
+        )
         x = self.proj(x).flatten(2).transpose(1, 2)  # B Ph*Pw C
         if self.norm is not None:
             x = self.norm(x)

--- a/src/foundation_models/SoftCON/models/dinov2/layers/patch_embed.py
+++ b/src/foundation_models/SoftCON/models/dinov2/layers/patch_embed.py
@@ -71,12 +71,12 @@ class PatchEmbed(nn.Module):
         _, _, H, W = x.shape
         patch_H, patch_W = self.patch_size
 
-        assert (
-            H % patch_H == 0
-        ), f"Input image height {H} is not a multiple of patch height {patch_H}"
-        assert (
-            W % patch_W == 0
-        ), f"Input image width {W} is not a multiple of patch width: {patch_W}"
+        assert H % patch_H == 0, (
+            f"Input image height {H} is not a multiple of patch height {patch_H}"
+        )
+        assert W % patch_W == 0, (
+            f"Input image width {W} is not a multiple of patch width: {patch_W}"
+        )
 
         x = self.proj(x)  # B C H W
         H, W = x.size(2), x.size(3)

--- a/src/foundation_models/SoftCON/models/dinov2/vision_transformer.py
+++ b/src/foundation_models/SoftCON/models/dinov2/vision_transformer.py
@@ -314,9 +314,9 @@ class DinoVisionTransformer(nn.Module):
             x = blk(x)
             if i in blocks_to_take:
                 output.append(x)
-        assert len(output) == len(
-            blocks_to_take
-        ), f"only {len(output)} / {len(blocks_to_take)} blocks found"
+        assert len(output) == len(blocks_to_take), (
+            f"only {len(output)} / {len(blocks_to_take)} blocks found"
+        )
         return output
 
     def _get_intermediate_layers_chunked(self, x, n=1):
@@ -332,9 +332,9 @@ class DinoVisionTransformer(nn.Module):
                 if i in blocks_to_take:
                     output.append(x)
                 i += 1
-        assert len(output) == len(
-            blocks_to_take
-        ), f"only {len(output)} / {len(blocks_to_take)} blocks found"
+        assert len(output) == len(blocks_to_take), (
+            f"only {len(output)} / {len(blocks_to_take)} blocks found"
+        )
         return output
 
     def get_intermediate_layers(

--- a/src/foundation_models/anysat_wrapper.py
+++ b/src/foundation_models/anysat_wrapper.py
@@ -19,7 +19,9 @@ class AnySatClassification(LightningTask):
 
         if model_config.freeze_backbone:
             self.freeze(self.encoder)
-        self.linear_classifier = nn.Linear(model_config.embed_dim, data_config.num_classes)
+        self.linear_classifier = nn.Linear(
+            model_config.embed_dim, data_config.num_classes
+        )
         self.criterion = (
             nn.MultiLabelSoftMarginLoss()
             if data_config.multilabel

--- a/src/foundation_models/croma_wrapper.py
+++ b/src/foundation_models/croma_wrapper.py
@@ -2,6 +2,8 @@ from .lightning_task import LightningTask
 from .CROMA.use_croma import PretrainedCROMA
 import torch.nn as nn
 import torch
+import os
+from huggingface_hub import hf_hub_download
 
 # use mmsegmentation for upernet+mae
 from mmseg.models.necks import Feature2Pyramid
@@ -12,6 +14,19 @@ from util.misc import resize, seg_metric, cls_metric
 class CromaClassification(LightningTask):
     def __init__(self, args, model_config, data_config):
         super().__init__(args, model_config, data_config)
+
+        # look for pretrained weights
+        dir = os.getenv("MODEL_WEIGHTS_DIR")
+        filename = model_config.pretrained_path
+        path = os.path.join(dir, filename)
+        if not os.path.exists(path):
+            # download the weights from HF
+            hf_hub_download(
+                repo_id="antofuller/CROMA",
+                filename=filename,
+                cache_dir=dir,
+                local_dir=dir,
+            )
 
         self.encoder = PretrainedCROMA(
             pretrained_path=model_config.pretrained_path,

--- a/src/foundation_models/dinov2_wrapper.py
+++ b/src/foundation_models/dinov2_wrapper.py
@@ -25,7 +25,9 @@ class DinoV2Classification(LightningTask):
         self.encoder = torch.hub.load("facebookresearch/dinov2", model_config.dino_size)
         if model_config.freeze_backbone:
             self.freeze(self.encoder)
-        self.linear_classifier = nn.Linear(model_config.embed_dim, data_config.num_classes)
+        self.linear_classifier = nn.Linear(
+            model_config.embed_dim, data_config.num_classes
+        )
         self.criterion = (
             nn.MultiLabelSoftMarginLoss()
             if data_config.multilabel

--- a/src/main.py
+++ b/src/main.py
@@ -79,4 +79,5 @@ def main(cfg: DictConfig):
 
 
 if __name__ == "__main__":
+    os.environ["MODEL_WEIGHTS_DIR"] = os.getenv("MODEL_WEIGHTS_DIR", "./fm_weights")
     main()


### PR DESCRIPTION
Since people on different machines should not go through the config files to change all the paths, this PR introduces an env variable.

Each FM wrapper checks whether the pretrained filename is present under the given `env["MODEL_WEIGHTS_DIR"]` and otherwise downloads the file to that location. So the configs should only contain the filename of the ckeckpoint file.

I have not checked whether all the automatic downloads work.